### PR TITLE
CASMCMS-7900 - fix postgres chart setting for upgrades.

### DIFF
--- a/kubernetes/cray-console-data/values.yaml
+++ b/kubernetes/cray-console-data/values.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # Please refer to https://github.com/Cray-HPE/base-charts/tree/master/kubernetes/cray-service/values.yaml
 # for more info on values you can set/override
 # Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
@@ -60,6 +83,8 @@ cray-service:
       console: []
     databases:
       service_db: console
+    tls:
+      enabled: true
 
   ingress:
     enabled: true


### PR DESCRIPTION
## Summary and Scope

The certificate handling of the postgres pods was not working on an upgrade from csm-1.0.x -> csm-1.2.  This fixes the chart setting to allow the upgraded pod to read the needed k8s secrets during the upgrade operation.

See https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5404 for details.

## Issues and Related PRs
* Resolves [CASMCMS-7900](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7900)

## Testing
### Tested on:
  * `Drax`

### Test description:

Drax has csm-1.0.10 installed.  I used helm to upgrade to the new version without issues.  I then used helm rollback to revert to the original version.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be a low risk change as it is following the suggestion of the PET team after they investigated the upgrade issue.  There is no code change for this, just the helm chart update.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

