### PR TITLE
CASMCMS-7900 - Update cray service base chart for postgres update issue.

### DIFF
--- a/kubernetes/cray-console-data/Chart.yaml
+++ b/kubernetes/cray-console-data/Chart.yaml
@@ -33,7 +33,7 @@ sources:
   - "https://github.com/Cray-HPE/console-data"
 dependencies:
   - name: cray-service
-    version: ^7.0.0
+    version: ^8.0.0
     repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"
 maintainers:
   - name: dlaine-hpe


### PR DESCRIPTION
## Summary and Scope

The certificate handling of the postgres pods was not working on an upgrade from csm-1.0.x -> csm-1.2. This fixes the chart setting to allow the upgraded pod to read the needed k8s secrets during the upgrade operation.

See https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5404 for details.

## Issues and Related PRs
* Resolves [CASMCMS-7900](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7900)

## Testing
### Tested on:

  * `Mug`

### Test description:
Mug has csm-1.2.something installed. I used helm to upgrade to the new version without issues. I then used helm rollback to revert to the original version.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is just picking up the new version of the cray-service base chart.  I did the install to make sure nothing incompatible was added so we should be good. 

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

