### PR TITLE
CASMCMS-7830 - update to newest alpine base image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-
 ### Changed
+ - CASMCMS-7830: Update the base image to newer version.
 
 [1.0.0] - (no date)

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # Dockerfile for the console-data service
 
 # Build will be where we build the go binary
-FROM arti.dev.cray.com/baseos-docker-master-local/golang:1.16-alpine3.13 as build
+FROM artifactory.algol60.net/docker.io/library/golang:1.16-alpine as build
 RUN set -eux \
     && apk add --upgrade --no-cache apk-tools \
     && apk update \
@@ -48,7 +48,7 @@ RUN set -ex && go build -v -i -o /app/console_data_svc $GOPATH/src/*.go
 
 ### Final Stage ###
 # Start with a fresh image so build tools are not included
-FROM artifactory.algol60.net/docker.io/alpine:3.13.5 as base
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15 as base
 
 # Copy in the needed files
 COPY --from=build /app/console_data_svc /app/

--- a/Dockerfile.integration.test
+++ b/Dockerfile.integration.test
@@ -23,7 +23,7 @@
 #
 # This file only exists as a means to run tests in an automated fashion.
 
-FROM arti.dev.cray.com/baseos-docker-master-local/golang:1.14-alpine3.12 as testbase
+FROM artifactory.algol60.net/docker.io/library/golang:1.16-alpine as testbase
 
 RUN set -ex \
     && apk add --upgrade --no-cache apk-tools \

--- a/docker-compose-devel.yaml
+++ b/docker-compose-devel.yaml
@@ -29,7 +29,7 @@ networks:
 services:
   condat-postgres:
     hostname: console-data-cray-console-data-postgres
-    image: arti.dev.cray.com/third-party-docker-stable-local/postgres:11-alpine
+    image: artifactory.algol60.net/artifactory/csm-docker/stable/docker.io/postgres:11-alpine
     environment:
       - POSTGRES_PASSWORD=console
       - POSTGRES_USER=console

--- a/docker-compose-integration-test.yaml
+++ b/docker-compose-integration-test.yaml
@@ -29,7 +29,7 @@ networks:
 services:
   condat-postgres:
     hostname: console-data-cray-console-data-postgres
-    image: arti.dev.cray.com/third-party-docker-stable-local/postgres:11-alpine
+    image: artifactory.algol60.net/artifactory/csm-docker/stable/docker.io/postgres:11-alpine
     environment:
       - POSTGRES_PASSWORD=console
       - POSTGRES_USER=console


### PR DESCRIPTION
## Summary and Scope

Update the alpine base image version and shift to the ones on algol60 that are being rebuilt nightly for better automatic CVE remediation.

## Issues and Related PRs
* Resolves [CASMCMS-7830](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7830)

## Testing
### Tested on:
  * `Drax`

### Test description:

Installed via helm on Drax with the other console services.  Did complete test with flushing cached data and made sure all new services came up and operated as expected, including connecting to live console sessions on compute nodes.  Rolled back to previous installed version when complete and re-tested.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - not applicable
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Fairly minor risk - there are no major dependencies on the base images and was completely tested on a live system.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable