### PR TITLE
Updates the base service chart to 8.2.0 to allow for compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.4.0] - 2022-07-12
 ### Changed
+ - CASMINST-5145: Update the base service chart to pull in necessary changes for updgraded istio
  - CASMCMS-7830: Update the base image to newer version.
 
 [1.0.0] - (no date)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+ - CASMINST-5145: Update the base service chart to pull in necessary changes for updgraded istio
 
 ## [1.4.0] - 2022-07-12
 ### Changed
- - CASMINST-5145: Update the base service chart to pull in necessary changes for updgraded istio
  - CASMCMS-7830: Update the base image to newer version.
 
 [1.0.0] - (no date)

--- a/kubernetes/cray-console-data/Chart.yaml
+++ b/kubernetes/cray-console-data/Chart.yaml
@@ -33,7 +33,7 @@ sources:
   - "https://github.com/Cray-HPE/console-data"
 dependencies:
   - name: cray-service
-    version: ^8.0.0
+    version: ^8.2.0
     repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"
 maintainers:
   - name: dlaine-hpe


### PR DESCRIPTION
...with upstream Istio and how it configures TLS between pods. These changes are exposed via an updated basechart.

## Summary and Scope

Istio exposes SSL-less between pod communication for specific address mappings for postgres, however the addresss used changed with an upstream istio upgrade. In order to utilize the new address, our service chart needs to inherit from an upgraded CSM base service chart that has this information in it.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5145](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5145)

## Testing

Do no harm testing on older istio release on internal system.

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

Sync'd images and chart to hardware system and stood up the new chart and ensure that it works as advertised (be able to chat with its postgres db).

## Pull Request Checklist

- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
