### PR TITLE
CASMCMS-8140 - correctly handle Hill nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
  - CASMINST-5145: Update the base service chart to pull in necessary changes for updgraded istio
+ - CASMCMS-8140: Fix handling Hill nodes.
 
 ## [1.4.0] - 2022-07-12
 ### Changed


### PR DESCRIPTION
## Summary and Scope

In csm-1.2, hsm changed so that the 'node class' can be either 'Mountain', 'River', or 'Hill'.  The 'hill' types were not getting picked up by console services.  This set of changes looks for records containing 'Hill' and treats them correctly.

## Issues and Related PRs
* Resolves [CASMCMS-8140](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8140)

## Testing
### Tested on:

  * `Loki`

### Test description:

I installed the new version via helm and observed that Hill nodes were correctly picked up by console services and connections and logging were established.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

This is a fairly low risk change, it just needs to handle the 'Hill' type in the existing records.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
