### PR TITLE
CASMCMS-8156 - fix bug with adding Hill node support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+ - CASMCMS-8156: Fix bug in handling Hill nodes.
 
 ## [1.6.0] - 2022-08-04
 ### Changed

--- a/console_data_svc/datastore.go
+++ b/console_data_svc/datastore.go
@@ -156,7 +156,7 @@ func dbConsolePodAcquireNodes(pod_id string, numMtn, numRvr int) (rowsAffected i
 			newNodes, newErrList, newAcquired := acquireNodesOfType("Hill", numMtn-len(acquired))
 			if len(newNodes) > 0 {
 				if len(nodes) > 0 {
-					nodes += fmt.Sprintf(",'%s' ", newNodes)
+					nodes += fmt.Sprintf(", %s ", newNodes)
 				} else {
 					nodes = newNodes
 				}
@@ -171,7 +171,7 @@ func dbConsolePodAcquireNodes(pod_id string, numMtn, numRvr int) (rowsAffected i
 		newNodes, newErrList, newAcquired := acquireNodesOfType("River", numRvr)
 		if len(newNodes) > 0 {
 			if len(nodes) > 0 {
-				nodes += fmt.Sprintf(",'%s' ", newNodes)
+				nodes += fmt.Sprintf(", %s ", newNodes)
 			} else {
 				nodes = newNodes
 			}


### PR DESCRIPTION
## Summary and Scope

The last fix to incorporate Hill nodes into console services had a bug when it was concatenating node lists together which resulted in malformed sql queries.  This prevented the console services from acquiring nodes when there were mixed types in the same acquisition call. This fixes the node lists.

## Issues and Related PRs
* Resolves [CASMCMS-8156](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8156)

## Testing
### Tested on:
  * `Loki`

### Test description:

I installed the new console-data service via helm, then cleared all console connections and information from the system.  I then watched as the mixed node types were acquired at the same time and successfully interacted with the database updates.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - not applicable
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be a low risk change.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
