### PR TITLE
CASMCMS-8041: Correct minor spelling errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.6.0] - 2022-08-04
 ### Changed
- - CASMINST-5145: Update the base service chart to pull in necessary changes for updgraded istio
+ - CASMINST-5145: Update the base service chart to pull in necessary changes for upgraded istio
  - CASMCMS-8140: Fix handling Hill nodes.
 
 ## [1.4.0] - 2022-07-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
  - CASMCMS-8156: Fix bug in handling Hill nodes.
+ - Spelling corrections
 
 ## [1.6.0] - 2022-08-04
 ### Changed

--- a/console_data_svc/datastore.go
+++ b/console_data_svc/datastore.go
@@ -69,11 +69,11 @@ func prepareDB() (err error) {
 	create_table := `
 	CREATE TABLE IF NOT EXISTS ownership (
 		node_name VARCHAR( 50 )  PRIMARY KEY NOT NULL CHECK (node_name <> ''),
-        node_bmc_name VARCHAR( 50 )  NOT NULL CHECK (node_bmc_name <> ''),
-        node_bmc_fqdn VARCHAR( 50 )  NOT NULL CHECK (node_bmc_fqdn <> ''),
-        node_class VARCHAR( 50 )  NOT NULL CHECK (node_class <> ''),
-        node_nid_number INTEGER  NOT NULL CHECK (node_nid_number <> 0),
-        node_role VARCHAR( 50 )  NOT NULL CHECK (node_role <> ''),
+		node_bmc_name VARCHAR( 50 )  NOT NULL CHECK (node_bmc_name <> ''),
+		node_bmc_fqdn VARCHAR( 50 )  NOT NULL CHECK (node_bmc_fqdn <> ''),
+		node_class VARCHAR( 50 )  NOT NULL CHECK (node_class <> ''),
+		node_nid_number INTEGER  NOT NULL CHECK (node_nid_number <> 0),
+		node_role VARCHAR( 50 )  NOT NULL CHECK (node_role <> ''),
 		console_pod_id VARCHAR( 50 ),
 		last_updated TIMESTAMP,
 		heartbeat TIMESTAMP
@@ -85,7 +85,7 @@ func prepareDB() (err error) {
 	return nil
 }
 
-// aquireNodesOfType will get a set of nodes for a particular type
+// acquireNodesOfType will get a set of nodes for a particular type
 func acquireNodesOfType(nodeType string, numNodes int) (nodes string, errList []string, acquired []NodeConsoleInfo) {
 	errList = []string{}
 	acquired = []NodeConsoleInfo{}
@@ -225,27 +225,27 @@ func dbUpdateNodes(ncis *[]NodeConsoleInfo) (rowsInserted int64, err error) {
 	var errList []string
 	rowsInserted = 0
 	sql := `
-        insert into ownership (node_name,
-          node_bmc_name,
-          node_bmc_fqdn,
-          node_class,
-          node_nid_number,
-          node_role,
-          console_pod_id,
-          last_updated,
-	      heartbeat)
-        values
-          ($1,
-          $2,
-          $3,
-          $4,
-          $5,
-          $6,
-          NULL,
-          now(),
-	      NULL)
-        on conflict (node_name) do nothing
-    `
+		insert into ownership (node_name,
+		  node_bmc_name,
+		  node_bmc_fqdn,
+		  node_class,
+		  node_nid_number,
+		  node_role,
+		  console_pod_id,
+		  last_updated,
+		  heartbeat)
+		values
+		  ($1,
+		  $2,
+		  $3,
+		  $4,
+		  $5,
+		  $6,
+		  NULL,
+		  now(),
+		  NULL)
+		on conflict (node_name) do nothing
+	`
 	for _, nci := range *ncis {
 		result, err := DB.Exec(sql,
 			nci.NodeName,
@@ -313,8 +313,8 @@ func dbFindConsolePodForNode(nci *NodeConsoleInfo) (err error) {
 	// Look for the node and if found set *nci.NodeConsoleName = console_pod_id
 	// Return any error found.
 	sqlStmt := `
-        select console_pod_id from ownership where node_name=$1
-    `
+		select console_pod_id from ownership where node_name=$1
+	`
 	if nci == nil || nci.NodeName == "" {
 		return errors.New("Nil or empty NodeName.")
 	}
@@ -394,7 +394,7 @@ func dbConsolePodHeartbeat(pod_id string, ncis *[]NodeConsoleInfo) (rowsAffected
 	}
 	// Let the caller see the list that was not updated (if any).
 	for _, nci := range notUpdated {
-		log.Printf("nci not updaed: %s", nci.NodeName)
+		log.Printf("nci not updated: %s", nci.NodeName)
 	}
 
 	if len(errList) > 0 {

--- a/console_data_svc/main.go
+++ b/console_data_svc/main.go
@@ -55,7 +55,7 @@ func main() {
 	// Enable debug logging if requested.
 	debugLog.Init()
 
-	log.Printf("Console data serivce starting")
+	log.Printf("Console data service starting")
 
 	// Setup a channel to wait for the os to tell us to stop.
 	// NOTE - This must be set up before initializing anything that needs

--- a/console_data_svc/restapi.go
+++ b/console_data_svc/restapi.go
@@ -57,7 +57,7 @@ acquireNodes(podId, numRiver, numMtn) → returns list of nodes and assigns them
   Give me up to 1k mtgn and 500 river.
   Makes the assignments based on what is available.
   Return the new list of nodes (consoleNI struct) of what was assigned.
-     May return nothing in the vast majority of times.
+	 May return nothing in the vast majority of times.
 
 */
 func consolePodAcquireNodes(w http.ResponseWriter, r *http.Request) {
@@ -219,7 +219,7 @@ func findConsolePodForNode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Let the caller know we were successful.  The console pod
-	// is part of the repsonse in nci.
+	// is part of the response in nci.
 	SendResponseJSON(w, http.StatusOK, nci)
 	return
 }

--- a/console_data_svc/router.go
+++ b/console_data_svc/router.go
@@ -22,7 +22,7 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// This file contains functionality for defining and handlng http routing.
+// This file contains functionality for defining and handling http routing.
 
 package main
 
@@ -36,7 +36,7 @@ import (
 	"strings"
 )
 
-// httpRoute specifies the method, uri regex and the hendler.
+// httpRoute specifies the method, uri regex and the handler.
 type httpRoute struct {
 	httpMethod string
 	uriRegex   *regexp.Regexp

--- a/integration_test/consolepod.go
+++ b/integration_test/consolepod.go
@@ -112,14 +112,14 @@ type ConsoleApiOp struct {
 // statusCode - the http response code
 // ncisAcquired - the list of nodes acquired
 // err - any error
-func (o *ConsoleApiOp) Acquire(cosole_pod_id string, numMtn, numRvr int) (statusCode int, ncisAcquired []NodeConsoleInfo, err error) {
+func (o *ConsoleApiOp) Acquire(console_pod_id string, numMtn, numRvr int) (statusCode int, ncisAcquired []NodeConsoleInfo, err error) {
 
-	if cosole_pod_id == "" {
-		return 0, nil, errors.New("cosole_pod_id is required but was empty")
+	if console_pod_id == "" {
+		return 0, nil, errors.New("console_pod_id is required but was empty")
 	}
 
 	uri := "http://cray-console-data/v1/consolepod/%s/acquire"
-	uri = fmt.Sprintf(uri, cosole_pod_id)
+	uri = fmt.Sprintf(uri, console_pod_id)
 	client := &http.Client{Timeout: 15 * time.Second}
 	o.ReqData.NumMtn = numMtn
 	o.ReqData.NumRvr = numRvr

--- a/integration_test/helpers.go
+++ b/integration_test/helpers.go
@@ -22,7 +22,7 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// This file contains helper methods to suport test verification.
+// This file contains helper methods to support test verification.
 
 package main
 
@@ -36,8 +36,8 @@ import (
 	"time"
 )
 
-// Datastore is a collection db cnetric of helper methods for use as needed
-// to assist in testing by proviging db operations not included in the API.
+// Datastore is a collection of db-centric helper methods for use as needed
+// to assist in testing by providing db operations not included in the API.
 type DataStore struct {
 	DB *sql.DB
 }
@@ -92,8 +92,8 @@ func (ds *DataStore) Close() {
 // RemoveAll deletes all items from the console ownership.
 func (ds *DataStore) RemoveAll() (rowsAffected int64, err error) {
 	sqlStmt := `
-        delete from ownership
-    `
+		delete from ownership
+	`
 	result, err := ds.DB.Exec(sqlStmt)
 	rowsAffected = 0
 	if err != nil {
@@ -111,8 +111,8 @@ func (ds *DataStore) RemoveAll() (rowsAffected int64, err error) {
 // CheckConn will try to execute a query
 func (ds *DataStore) CheckConn() (err error) {
 	sqlStmt := `
-        select count(1) from ownership
-    `
+		select count(1) from ownership
+	`
 	_, err = ds.DB.Exec(sqlStmt)
 	if err != nil {
 		errMsg := fmt.Sprintf("WARN: GetCount: There is a SELECT error: %s", err)
@@ -126,8 +126,8 @@ func (ds *DataStore) CheckConn() (err error) {
 // GetCount returns the number of records in console ownership.
 func (ds *DataStore) GetCount() (recordCount int64, err error) {
 	sqlStmt := `
-        select count(1) from ownership
-    `
+		select count(1) from ownership
+	`
 	result, err := ds.DB.Query(sqlStmt)
 	if err != nil {
 		errMsg := fmt.Sprintf("WARN: GetCount: There is a SELECT error: %s", err)

--- a/integration_test/inventory.go
+++ b/integration_test/inventory.go
@@ -218,7 +218,7 @@ func inventoryCreateVolume(testName string) {
 	if err != nil {
 		fail(testName, err)
 	}
-	// The exisitng record count does not change.
+	// The existing record count does not change.
 	err = assertEqualInt(2500+500+5000, int(recordCount), "")
 	if err != nil {
 		fail(testName, err)
@@ -239,7 +239,7 @@ func inventoryCreateVolume(testName string) {
 	pass(testName)
 }
 
-// inventoryDelete verifies inverntory remov
+// inventoryDelete verifies inverntory remove
 func inventoryDelete(testName string) {
 
 }


### PR DESCRIPTION
## Summary and Scope

Correct spelling errors / typos in the repo. They have not caused any reported problems, but we may as well fix them. No need to make a manifest PR, though -- these can just get picked up the next time we make a release.

This PR also fixes some inconsistent indentation in a couple of the files. And one of the spelling typos was in the name of a variable, but it is a local variable for a function, so fixing its name should have no unintended repercussions.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
