### PR TITLE
CASMCMS-8423 - linting changes due to new version of gofmt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.3] - 2022-02-24
+### Changed
+- CASMCMS-8423 - linting changes due to new version of gofmt.
+
 ## [1.6.2] - 2022-12-20
 ### Added
 - Add Artifactory authentication to Jenkinsfile

--- a/console_data_svc/datastore.go
+++ b/console_data_svc/datastore.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -408,10 +408,8 @@ func dbConsolePodHeartbeat(pod_id string, ncis *[]NodeConsoleInfo) (rowsAffected
 	}
 }
 
-/*
-dbConsolePodRelease will remove the console pod from all nodes in the list.
-  takes []NodeConsoleInfo - pod no longer monitors these nodes, free for acquisition
-*/
+// dbConsolePodRelease will remove the console pod from all nodes in the list.
+// takes []NodeConsoleInfo - pod no longer monitors these nodes, free for acquisition
 func dbConsolePodRelease(pod_id string, ncis *[]NodeConsoleInfo) (rowsAffected int64, err error) {
 	// exit fast
 	if pod_id == "" || ncis == nil || len(*ncis) == 0 {
@@ -454,10 +452,8 @@ func dbConsolePodRelease(pod_id string, ncis *[]NodeConsoleInfo) (rowsAffected i
 
 }
 
-/*
-dbDeleteNodes will remove nodes from the provided list from the inventory.
-  takes []NodeConsoleInfo - these nodes are no longer in the system at all
-*/
+// dbDeleteNodes will remove nodes from the provided list from the inventory.
+// takes []NodeConsoleInfo - these nodes are no longer in the system at all
 func dbDeleteNodes(ncis *[]NodeConsoleInfo) (rowsAffected int64, err error) {
 	// exit fast
 	if ncis == nil || len(*ncis) == 0 {

--- a/console_data_svc/restapi.go
+++ b/console_data_svc/restapi.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -51,15 +51,12 @@ func newNCI(nodeName, bmcName, bmcFqdn, class, role string, nid int) NodeConsole
 		Class: class, NID: nid, Role: role}
 }
 
-/*
-acquireNodes(podId, numRiver, numMtn) → returns list of nodes and assigns them to pod with current timestamp (called by console-node)
-  pod_id will be stateful set named (node-1, node-1, node-x)
-  Give me up to 1k mtgn and 500 river.
-  Makes the assignments based on what is available.
-  Return the new list of nodes (consoleNI struct) of what was assigned.
-     May return nothing in the vast majority of times.
-
-*/
+// acquireNodes(podId, numRiver, numMtn) → returns list of nodes and assigns them to pod with current timestamp (called by console-node)
+// pod_id will be stateful set named (node-1, node-1, node-x)
+// Give me up to 1k mtgn and 500 river.
+// Makes the assignments based on what is available.
+// Return the new list of nodes (consoleNI struct) of what was assigned.
+// May return nothing in the vast majority of times.
 func consolePodAcquireNodes(w http.ResponseWriter, r *http.Request) {
 	type ReqData struct {
 		NumMtn int `json:"nummtn"` // Requested number of Mountain nodes
@@ -283,13 +280,10 @@ func updateNodes(w http.ResponseWriter, r *http.Request) {
 
 }
 
-/*
-clearStaleNodes(timestamp) → looks for HSM nodes with timestamp older than the given duration (in minutes) and
-clears pod info (called by console-operator) for each stale node
-  Remove the pod entry from the liveness table
-  update the ownership table setting unsetting the conman-pod-id where conman-pod-id = state pod name
-
-*/
+// clearStaleNodes(timestamp) → looks for HSM nodes with timestamp older than the given duration (in minutes) and
+// clears pod info (called by console-operator) for each stale node
+// Remove the pod entry from the liveness table
+// update the ownership table setting unsetting the conman-pod-id where conman-pod-id = state pod name
 func clearStaleNodes(w http.ResponseWriter, r *http.Request) {
 	durationStr := getField(r, 0) // Duration in minutes
 	if durationStr == "" {
@@ -332,10 +326,8 @@ func clearStaleNodes(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-/*
-consolePodRelease -> takes []NodeConsoleInfo, pod no longer monitors these nodes, free for acquisition
-  update the ownership table setting the conman-pod-id to NULL where node_name in ( nci.NodeName[,nci.NodeName]... )
-*/
+// consolePodRelease -> takes []NodeConsoleInfo, pod no longer monitors these nodes, free for acquisition
+// update the ownership table setting the conman-pod-id to NULL where node_name in ( nci.NodeName[,nci.NodeName]... )
 func consolePodRelease(w http.ResponseWriter, r *http.Request) {
 	pod_id := getField(r, 0)
 	log.Printf("consolePodRelease pod_id=%s\n", pod_id)
@@ -397,10 +389,8 @@ func consolePodRelease(w http.ResponseWriter, r *http.Request) {
 	SendResponseJSON(w, http.StatusOK, body)
 }
 
-/*
-deleteNodes -> takes []NodeConsoleInfo, - these nodes are no longer in the system at all
-  delete from ownership where node_name in ( nci.NodeName[,nci.NodeName]... )
-*/
+// deleteNodes -> takes []NodeConsoleInfo, - these nodes are no longer in the system at all
+// delete from ownership where node_name in ( nci.NodeName[,nci.NodeName]... )
 func deleteNodes(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("deleteNodes\n")


### PR DESCRIPTION
## Summary and Scope

There was a new version of 'go' installed on the image for the build pipeline. The new 'gofmt' linter objected to a couple of the comments and forced us to change them to allow the linting step to complete happily so the build would complete.

## Issues and Related PRs
* Resolves [CASMCMS-8423](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8423)

## Testing
### Tested on:
  * `Surtur`

### Test description:

Installed the new version on surtur and verified the console services work correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y 
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - just changing the format of comments.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
