### PR TITLE
CASMCMS-8899 - support for Paradise nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CASMCMS-8899 - add support for Paradise (xd224) nodes.
+
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds


### PR DESCRIPTION
## Summary and Scope

Paradise nodes (Cray xd224) needs to connect to the consoles through ssh but with a username and password, which is a different way of connecting than to regular river, mountain, or hill nodes. The changes in this service mostly have to do with identifying and labeling nodes that are paradise hardware.

## Issues and Related PRs
* Resolves [CASMCMS-8899](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8899)

## Testing
### Tested on:
  * `Tyr`

### Test description:

The new services were installed via helm and I manually tested that the existing mountain, hill, river, and paradise nodes all are identified correctly and the console services can connect with them.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk, but there are changes that impact the other node types as well as the new paradise nodes.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
