### PR TITLE
CASMCMS-9122: Upgrade cray-service chart for postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMPET-7065 - update to cray-services:11.0.0 base chart
 
 ## [2.1.0] - 2024-05-03
 ### Added

--- a/kubernetes/cray-console-data/Chart.yaml
+++ b/kubernetes/cray-console-data/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,7 +33,7 @@ sources:
   - "https://github.com/Cray-HPE/console-data"
 dependencies:
   - name: cray-service
-    version: ^8.2.0
+    version: ^11.0.0
     repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"
   - name: cray-postgresql
     version: ^1.0.0


### PR DESCRIPTION
## Summary and Scope

Update cray-service base chart version. In the upgrade to Kubernetes version 1.24, There were changes that affected postgres. Upgrading the cray-service chart addresses those changes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-9122]

## Testing

### Tested on:

  * A build succeeded
  * Deployed it on Fanta.

### Test description:

  * Deployed it on Fanta. Nothing crashed. So we're good, right?
  * 
- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

