### PR TITLE
CASMTRIAGE-7594 - better resiliency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- CASMTRIAGE-7594 - clean up resilience.
+
 ## [2.2.0] - 2024-09-03
 ### Changed
 - CASMPET-7065 - update to cray-services:11.0.0 base chart

--- a/console_data_svc/router.go
+++ b/console_data_svc/router.go
@@ -91,6 +91,11 @@ var httpRoutes = []httpRoute{
 	// Returns a NodeConsoleInfo with the console pod name or
 	// empty pod name if not assigned.
 	createRoute("GET", "/v1/consolepod/([0-9a-z]+)", findConsolePodForNode),
+
+	// Find the console pod for the node (specified in the URI).
+	// Returns a NodeConsoleInfo with the console pod name or
+	// empty pod name if not assigned.
+	createRoute("GET", "/v1/activepods", getNumActiveNodePods),
 }
 
 func createRoute(httpMethod, uriPattern string, handler http.HandlerFunc) httpRoute {


### PR DESCRIPTION
## Summary and Scope

There was a problem where a worker node's console was not being monitored by anyone because it was getting assigned/unassigned to the console-node pod that was running on that worker and the other pod didn't have capacity to pick it up. The end result was it was getting picked up and dropped continually while forcing the conmand process to keep getting killed (resulting in incomplete logging of all the nodes in that pod).

The fix was to rework how node acquisition and rebalancing happens to be much more stable and aware of the current status of the services. This fix requires changes in all three console repos.

## Issues and Related PRs
* Resolves [CASMTRIAGE-7594](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7594)

## Testing
### Tested on:
  * `Surtur`

### Test description:

I installed all 3 new versions of the console services and monitored the node acquisition through pod rollout, then forced pod failures to insure the remaining pods picked up the orphaned nodes, then correctly rebalanced when all console-node pods were back up and running.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a medium size change, but I spent several days testing in all situations I could think up.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable